### PR TITLE
The validateFindByidParams now has a return value

### DIFF
--- a/src/validate.js
+++ b/src/validate.js
@@ -69,7 +69,7 @@ export function validateFindByidParams(params) {
   if (id <= 0) {
     throw new AppError("The id should be bigger than 0!");
   }
-
+  return params;
 }
 
 export function validateFindByStatusParams(params) {


### PR DESCRIPTION
The validateFindByidParams function in validate.js didn't had a return value since the last merge,  now it has a return value. Please accept the change.